### PR TITLE
Fix random instruction and pagination

### DIFF
--- a/src/components/InstructionsList.tsx
+++ b/src/components/InstructionsList.tsx
@@ -42,7 +42,7 @@ export const InstructionsList = ({
 
   // Fetch instructions
   useEffect(() => {
-    fetchInstructions(true);
+    fetchInstructions(page === 0);
   }, [searchQuery, selectedTags, selectedCategories, page]);
 
   const fetchInstructions = async (isFirstPage = false) => {

--- a/src/components/RandomInstructionHero.tsx
+++ b/src/components/RandomInstructionHero.tsx
@@ -61,7 +61,7 @@ export const RandomInstructionHero = () => {
             name
           )
         `)
-        .order("random()") // Note: This might not work in all databases, might need a different approach
+        .order("random")
         .limit(1)
         .single();
 


### PR DESCRIPTION
## Summary
- fix fetching random daily instruction using correct order clause
- fix instruction pagination to append results when loading more

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 7 errors in unrelated files)*
- `npx eslint src/components/RandomInstructionHero.tsx src/components/InstructionsList.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689007c4bb70832295a210718fdd14c7