### PR TITLE
fix: stabilize burger menu placement

### DIFF
--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -18,34 +18,26 @@ export const AppNavigation = ({ showBackToHome = false }: AppNavigationProps) =>
 
   useEffect(() => {
     const calculateScrollbarWidth = () => {
-      const outer = document.createElement('div');
-      outer.style.visibility = 'hidden';
-      outer.style.overflow = 'scroll';
-      document.body.appendChild(outer);
-
-      const inner = document.createElement('div');
-      outer.appendChild(inner);
-
-      const scrollbarWidth = outer.offsetWidth - inner.offsetWidth;
-      outer.parentNode?.removeChild(outer);
-
-      setScrollbarWidth(scrollbarWidth);
+      const width = window.innerWidth - document.documentElement.clientWidth;
+      setScrollbarWidth(width);
     };
 
     calculateScrollbarWidth();
-    window.addEventListener('resize', calculateScrollbarWidth);
-    return () => window.removeEventListener('resize', calculateScrollbarWidth);
+    window.addEventListener("resize", calculateScrollbarWidth);
+    return () => window.removeEventListener("resize", calculateScrollbarWidth);
   }, []);
 
   const handleMenuOpenChange = (open: boolean) => {
     if (open) {
-      // Prevent layout shift by accounting for scrollbar width
-      document.body.style.overflow = 'hidden';
-      document.body.style.paddingRight = `${scrollbarWidth}px`;
+      // Prevent layout shift by accounting for scrollbar width when present
+      document.body.style.overflow = "hidden";
+      if (scrollbarWidth > 0) {
+        document.body.style.paddingRight = `${scrollbarWidth}px`;
+      }
     } else {
       // Restore normal scrolling
-      document.body.style.overflow = '';
-      document.body.style.paddingRight = '';
+      document.body.style.overflow = "";
+      document.body.style.paddingRight = "";
     }
   };
 
@@ -62,11 +54,10 @@ export const AppNavigation = ({ showBackToHome = false }: AppNavigationProps) =>
 
       <DropdownMenu onOpenChange={handleMenuOpenChange}>
         <DropdownMenuTrigger asChild>
-          <Button 
-            variant="ghost" 
-            size="icon" 
+          <Button
+            variant="ghost"
+            size="icon"
             className="ml-auto"
-            style={{ marginRight: `${scrollbarWidth}px` }}
           >
             <Menu className="h-5 w-5" />
           </Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -101,7 +101,7 @@ const Index = () => {
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
         <header className="mb-8">
-          <div className="mb-4">
+          <div className="mb-6">
             <AppNavigation />
           </div>
           


### PR DESCRIPTION
## Summary
- prevent page shift when opening burger menu by compensating for scrollbar width
- align navigation spacing on the homepage with other pages

## Testing
- `npm run lint` *(fails: Unexpected any, forbidden require, react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689211f2bc7483228c9bb501129e0179