### PR TITLE
Refactor search persistence and instruction fetching

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -9,16 +9,7 @@ import {
 } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
-
-interface Tag {
-  id: number;
-  name: string;
-}
-
-interface Category {
-  id: number;
-  name: string;
-}
+import type { Category, Tag } from "@/types/filters";
 
 interface FilterBarProps {
   tags: Tag[];
@@ -41,20 +32,24 @@ export const FilterBar = ({
 }: FilterBarProps) => {
   const hasActiveFilters = selectedTags.length > 0 || selectedCategories.length > 0;
 
+  const toggleSelection = (
+    id: number,
+    selected: number[],
+    onChange: (ids: number[]) => void,
+  ) => {
+    onChange(
+      selected.includes(id)
+        ? selected.filter(existingId => existingId !== id)
+        : [...selected, id],
+    );
+  };
+
   const handleTagToggle = (tagId: number) => {
-    if (selectedTags.includes(tagId)) {
-      onTagsChange(selectedTags.filter(id => id !== tagId));
-    } else {
-      onTagsChange([...selectedTags, tagId]);
-    }
+    toggleSelection(tagId, selectedTags, onTagsChange);
   };
 
   const handleCategoryToggle = (categoryId: number) => {
-    if (selectedCategories.includes(categoryId)) {
-      onCategoriesChange(selectedCategories.filter(id => id !== categoryId));
-    } else {
-      onCategoriesChange([...selectedCategories, categoryId]);
-    }
+    toggleSelection(categoryId, selectedCategories, onCategoriesChange);
   };
 
   const removeTag = (tagId: number) => {

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+
+interface UsePersistentStateOptions<T> {
+  serialize?: (value: T) => string;
+  deserialize?: (value: string) => T;
+}
+
+const isBrowser = typeof window !== "undefined";
+
+export const usePersistentState = <T,>(
+  key: string,
+  defaultValue: T,
+  options: UsePersistentStateOptions<T> = {}
+) => {
+  const { serialize, deserialize } = options;
+  const isStringDefault = typeof defaultValue === "string";
+
+  const readValue = () => {
+    if (!isBrowser) {
+      return defaultValue;
+    }
+
+    const storedValue = window.localStorage.getItem(key);
+
+    if (storedValue === null) {
+      return defaultValue;
+    }
+
+    try {
+      if (deserialize) {
+        return deserialize(storedValue);
+      }
+
+      if (isStringDefault) {
+        return storedValue as unknown as T;
+      }
+
+      return JSON.parse(storedValue) as T;
+    } catch (error) {
+      console.warn(`Failed to parse localStorage value for key "${key}":`, error);
+      return defaultValue;
+    }
+  };
+
+  const [state, setState] = useState<T>(readValue);
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+
+    try {
+      const valueToStore = serialize
+        ? serialize(state)
+        : typeof state === "string"
+        ? (state as unknown as string)
+        : JSON.stringify(state);
+
+      window.localStorage.setItem(key, valueToStore);
+    } catch (error) {
+      console.warn(`Failed to save localStorage value for key "${key}":`, error);
+    }
+  }, [key, state, serialize]);
+
+  return [state, setState] as const;
+};

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -1,0 +1,9 @@
+export interface Tag {
+  id: number;
+  name: string;
+}
+
+export interface Category {
+  id: number;
+  name: string;
+}


### PR DESCRIPTION
## Summary
- add a reusable `usePersistentState` hook and shared filter types for tag/category state
- update the search page to restore filters through the new hook and guard async setup
- streamline instruction fetching logic with shared helpers and unified filter handling

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e102412e208322b6453b2266f97e20